### PR TITLE
fix: make path in coverage file optional

### DIFF
--- a/ruby/test/action.yml
+++ b/ruby/test/action.yml
@@ -9,7 +9,8 @@ inputs:
     required: false
   COVERAGE_ROOT_PATH:
     description: Root path for coverage files - make this overridable because of a bug in GitHub.
-    default: $GITHUB_WORKSPACE
+    # GitHub Actions do not support dynamic values, so default is an empty string.
+    default: ""
     required: false
   
 runs:
@@ -35,10 +36,12 @@ runs:
         DB_PORT: ${{ inputs.DB_PORT }}
         RAILS_ENV: test
     - name: Rename code coverage paths to be found by Sonarqube
+      env:
+        ROOT_PATH: ${{ inputs.COVERAGE_ROOT_PATH || $GITHUB_WORKSPACE }} 
       working-directory: ./coverage
       shell: bash
       run: |
-        sed -i 's@${{ inputs.COVERAGE_ROOT_PATH }}''@/github/workspace/@g' coverage.json
+        sed -i 's@${{ env.ROOT_PATH }}''@/github/workspace/@g' coverage.json
     - name: 'Upload coverage'
       uses: actions/upload-artifact@v3
       with:

--- a/ruby/test/action.yml
+++ b/ruby/test/action.yml
@@ -37,7 +37,9 @@ runs:
         RAILS_ENV: test
     - name: Rename code coverage paths to be found by Sonarqube
       env:
-        ROOT_PATH: ${{ inputs.COVERAGE_ROOT_PATH || $GITHUB_WORKSPACE }} 
+        # We used $HOME because $GITHUB_WORKSPACE is not pointing to the correct path.
+        # If GitHub fixes this, these actions might break. Using $COVERAGE_ROOT_PATH can be our workaround.
+        ROOT_PATH: ${{ inputs.COVERAGE_ROOT_PATH || $HOME }} 
       working-directory: ./coverage
       shell: bash
       run: |

--- a/ruby/test/action.yml
+++ b/ruby/test/action.yml
@@ -7,7 +7,11 @@ inputs:
   DB_PORT:
     description: Database port
     required: false
- 
+  COVERAGE_ROOT_PATH:
+    description: Root path for coverage files - make this overridable because of a bug in GitHub.
+    default: $GITHUB_WORKSPACE
+    required: false
+  
 runs:
   using: "composite"
   steps:
@@ -34,7 +38,7 @@ runs:
       working-directory: ./coverage
       shell: bash
       run: |
-        sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' coverage.json
+        sed -i 's@${{ inputs.COVERAGE_ROOT_PATH }}''@/github/workspace/@g' coverage.json
     - name: 'Upload coverage'
       uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
# What?

- Make the file path for the ruby/test action -> `Rename code coverage paths` overrideable.
- I had to do a bit of a weird thing by using `env` in the code coverage path fixing step because GHA composite actions don't support dynamic values as input

# Why?

- There is a really hard-to-detect bug where coverage output isn't being read properly by SonarQube because this step is not correctly fixing code coverage file paths. It should actually be using the same directory that `actions/checkout` puts code in, which seems to be `$HOME`. However, because many Flipp Ruby projects are getting the correct path and coverage, we need backwards-compatibility.

# 5 Whys Thinking

I felt this necessary to include because there's more to just getting PDA's repo coverage working again.

1. This is being missed by teams because you have to basically read through the SonarQube output line-by-line to determine if coverage works.
2. GitHub `$GITHUB_WORKSPACE` is what's breaking. Fundamentally, this is a workaround for their [bug](https://github.com/actions/runner/issues/2058). Basically, [the docs say](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables) that this is where our code should be checked out, and it's not. If this gets fixed, this possibly goes away.
3. The whole code coverage path fixing in Ruby projects tells me something is wonky with SimpleCov itself. It's very strange that it only outputs absolute paths. I tried quickly looking to see if this is configurable, but couldn't find anything.
4. We _should_ be able to use relative pathing from project root... but I remember that SonarQube vaguely has had trouble with that before.
5. Our choice to set `sonar.sources` to `/app` might have rippling side-effects, such as this. I originally started playing with those settings, but PDA didn't want to be too out of sync with the rest of Flipp, so we opted to just fix the bug in our PRs ([search-sieve](https://github.com/wishabi/search-sieve/pull/34/files), [geo-admin](https://github.com/wishabi/geo-admin/pull/64)).


