### PR TITLE
PD-376: Use coverpkg to specify all local packages

### DIFF
--- a/go/test/test.sh
+++ b/go/test/test.sh
@@ -6,6 +6,23 @@ TIMEOUT=$2
 
 cmd="go test 2>&1 ./... -coverprofile=coverage.out"
 
+# find non-ignored subdirectories
+file_list=()
+
+for dir in */; do
+   if ! git check-ignore -q "$dir"; then
+    file_list+=("./$dir...")
+   fi
+done
+
+# set delimiter to , so we can join the list with commas
+old_ifs=$IFS
+IFS=,
+package_list="${file_list[*]}"
+IFS=$old_ifs # put delimiter back to the original value
+
+cmd="$cmd -coverpkg $package_list"
+
 if [ -n "$TAGS" ]; then
   cmd="$cmd --tags=${TAGS}"
 fi


### PR DESCRIPTION
Our coverage tool was missing lines in the report. This is because we had a separate `tests` package which tested other functionality. By default, go's coverage tool assumes that a test in any package is _only_ testing code within the same package, so those tests basically got zero coverage.

This updates the Bash script so that it uses `.gitignore` to check for all non-ignored subdirectories of the project (so e.g. `mocks` and `gen` are not included). It then adds all non-ignored subdirectories as `-coverpkg` so we cover the entire app when looking for coverage.