### PR TITLE
fix: GitHub SHA calculation

### DIFF
--- a/sonarqube-scan/action.yml
+++ b/sonarqube-scan/action.yml
@@ -33,6 +33,7 @@ runs:
     - name: Get GitHub short SHA as version
       id: get-short-sha
       run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+      shell: bash
     - name: SonarQube Scan
       uses: sonarsource/sonarqube-scan-action@master
       env:

--- a/sonarqube-scan/action.yml
+++ b/sonarqube-scan/action.yml
@@ -30,6 +30,9 @@ runs:
       uses: actions/download-artifact@v3
       with:
         name: "${{ github.sha }}-lint-results.out"
+    - name: Get GitHub short SHA as version
+      id: get-short-sha
+      run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
     - name: SonarQube Scan
       uses: sonarsource/sonarqube-scan-action@master
       env:
@@ -37,4 +40,4 @@ runs:
         SONAR_HOST_URL: ${{ inputs.SONAR_HOST_URL }}
       with:
         args: >
-          -Dsonar.projectVersion=${GITHUB_SHA::7}
+          -Dsonar.projectVersion=${{ steps.get-short-sha.outputs.SHORT_SHA }}


### PR DESCRIPTION
- Had bash expansion where it wasn't possible
- Switched to using a step to output the short sha and relying on github expression to pass to sonarscan