### PR TITLE
fix: Removed continue on error from lint

### DIFF
--- a/ruby/lint/action.yml
+++ b/ruby/lint/action.yml
@@ -6,7 +6,6 @@ runs:
   steps:
     - name: Execute rubocop
       id: rubocop
-      continue-on-error: true
       shell: bash
       run: |
         bundle exec rubocop --format progress --format json --out rubocop/rubocop.json


### PR DESCRIPTION
Noticed lint error wasn't exiting in this PR: https://github.com/wishabi/search-sieve/pull/44

See this comment for details: https://github.com/wishabi/search-sieve/pull/44#issuecomment-1801814145