### PR TITLE
Hoist up common Go actions

### DIFF
--- a/deploy/eks/action.yml
+++ b/deploy/eks/action.yml
@@ -1,4 +1,4 @@
-name: 'eks-deploy'
+name: "eks-deploy"
 description: 'Custom GitHub action that deploys the repository to EKS using its "/deploy/build.sh" script'
 
 inputs:
@@ -17,11 +17,34 @@ inputs:
   AWS_REGION:
     description: AWS region to deploy to stored as secret
     required: true
-
+  SLACK_SUCCESS_CHANNEL_ID:
+    description: The Slack channel ID(s) to send successful deployment notifications
+    required: false
+  SLACK_FAILURE_CHANNEL_ID:
+    description: The Slack channel ID(s) to send failed deployment notifications
+    required: false
+  SLACK_BOT_TOKEN:
+    description: The Slack bot token to pass the data to
+    required: false
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
+    - name: Set branch variable
+      id: set-branch
+      shell: bash
+      run: |
+        if [ "${{ github.event_name }}" == "pull_request" ]; then
+          branch="${{ github.event.pull_request.head.ref }}"
+        else
+          branch="${{ github.ref }}"
+          branch="${branch#refs/heads/}"
+        fi
+        echo "branch=${branch}" >> $GITHUB_OUTPUT
+    - name: Get short sha
+      id: get-short-sha
+      run: echo "short_sha=`echo ${GITHUB_SHA::7}`" > $GITHUB_OUTPUT
+      shell: bash
     - name: Configuring AWS credentials
       uses: aws-actions/configure-aws-credentials@v2
       with:
@@ -38,7 +61,7 @@ runs:
       shell: bash
       run: |
         cmd="chmod +x ./deploy/build.sh && ./deploy/build.sh service deploy_eks --env=${{ inputs.ENV }}"
-        
+
         # Check if timeout is set and provide it as a flag
         if [ -n "${{ inputs.TIMEOUT }}" ]; then
           cmd="${cmd} --timeout=${{ inputs.TIMEOUT }}"
@@ -46,3 +69,141 @@ runs:
 
         # Execute command
         eval $cmd
+    - name: Notify slack channel on success
+      if: success() && inputs.SLACK_SUCCESS_CHANNEL_ID != null
+      uses: slackapi/slack-github-action@v1.24.0
+      env:
+        SLACK_BOT_TOKEN: ${{ inputs.SLACK_BOT_TOKEN }}
+      with:
+        channel-id: ${{ inputs.SLACK_SUCCESS_CHANNEL_ID }}
+        payload: |
+          {
+            "text": "EKS Deplloyment Succeeded",
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": "EKS Deployment Succeeded",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "divider"
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "*Repository*\n<https://github.com/${{ github.repository }}|${{ github.repository }}>\n\n*Environment*\n${{ inputs.ENV }}"
+                },
+                "accessory": {
+                  "type": "image",
+                  "image_url": "https://emoji.slack-edge.com/T02AJQYGN/shipped/43553cbf473da4d5.png",
+                  "alt_text": "deploy fail icon"
+                }
+              },
+              {
+                "type": "divider"
+              },
+              {
+                "type": "section",
+                "fields": [
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Branch*"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Commit*"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "${{ format('<https://github.com/{0}/commit/{1}|{2}>', github.repository, github.sha, steps.set-branch.outputs.branch)}}"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "${{ steps.get-short-sha.outputs.short_sha }}"
+                  }
+                ]
+              },
+              {
+                "type": "context",
+                "elements": [
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Triggered By:* ${{ github.triggering_actor }}"
+                  }
+                ]
+              }
+            ]
+          }
+    - name: Notify slack channel on failure
+      if: failure() && inputs.SLACK_FAILURE_CHANNEL_ID != null
+      uses: slackapi/slack-github-action@v1.24.0
+      env:
+        SLACK_BOT_TOKEN: ${{ inputs.SLACK_BOT_TOKEN }}
+      with:
+        channel-id: ${{ inputs.SLACK_FAILURE_CHANNEL_ID }}
+        payload: |
+          {
+            "text": "EKS Deployment Failed",
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": "EKS Deployment Failed",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "divider"
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "*Repository*\n<https://github.com/${{ github.repository }}|${{ github.repository }}>\n\n*Environment*\n${{ inputs.ENV }}"
+                },
+                "accessory": {
+                  "type": "image",
+                  "image_url": "https://emoji.slack-edge.com/T02AJQYGN/sad-cloud/d78efc194125ff42.png",
+                  "alt_text": "deploy fail icon"
+                }
+              },
+              {
+                "type": "divider"
+              },
+              {
+                "type": "section",
+                "fields": [
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Branch*"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Commit*"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "${{ format('<https://github.com/{0}/commit/{1}|{2}>', github.repository, github.sha, steps.set-branch.outputs.branch)}}"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "${{ steps.get-short-sha.outputs.short_sha }}"
+                  }
+                ]
+              },
+              {
+                "type": "context",
+                "elements": [
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Triggered By:* ${{ github.triggering_actor }}"
+                  }
+                ]
+              }
+            ]
+          }

--- a/go/build-and-test/action.yml
+++ b/go/build-and-test/action.yml
@@ -1,28 +1,41 @@
-name: "SonarQube Scan"
-description: "Runs various quality and security checks against changes"
+name: "Go Build & Test"
+description: "Build and test go repo"
+
 inputs:
-  SONAR_HOST_URL:
-    description: secret value
+  FLIPPCIRCLECIPULLER_REPO_TOKEN:
+    description: Flipp circleci repo token
     required: true
-  SONAR_TOKEN:
-    description: secret value
-    required: true
-  CHECK_LINTER:
-    description: whether to download and analyze linter results
-    default: false
+  BUF_BUILD_USER:
+    description: Buf CI user stored as secret
+    required: false
+  BUF_BUILD_API_TOKEN:
+    description: Buf API token stored as secret
+    required: false
   SLACK_CHANNEL_ID:
     description: The Slack channel ID(s) to send the data to
     required: false
   SLACK_BOT_TOKEN:
     description: The Slack bot token to pass the data to
     required: false
+  DB_HOST:
+    description: Database host
+    required: false
+  DB_USER:
+    description: Database user
+    required: false
+  DB_PASSWORD:
+    description: Database password
+    required: false
+  DB_PORT:
+    description: Database port
+    required: false
+  TEST_TAGS:
+    description: Test tags
+    required: false
 
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: Set branch variable
       id: set-branch
       shell: bash
@@ -38,30 +51,36 @@ runs:
       id: get-short-sha
       run: echo "short_sha=`echo ${GITHUB_SHA::7}`" > $GITHUB_OUTPUT
       shell: bash
-    - name: Downloading test report
-      uses: actions/download-artifact@v3
+    - name: Configure Go environment
+      uses: wishabi/github-actions/go/configure@v0
       with:
-        name: "${{ github.sha }}-test-report.out"
-    - name: Downloading coverage report
-      uses: actions/download-artifact@v3
+        FLIPPCIRCLECIPULLER_REPO_TOKEN: ${{ inputs.FLIPPCIRCLECIPULLER_REPO_TOKEN }}
+        BUF_BUILD_USER: ${{ inputs.BUF_BUILD_USER }}
+        BUF_BUILD_API_TOKEN: ${{ inputs.BUF_BUILD_API_TOKEN }}
+    - name: Generate local protos
+      run: make generate-buf
+      shell: bash
+    - name: Setup Go dependencies
+      uses: wishabi/github-actions/go/deps@v0
       with:
-        name: "${{ github.sha }}-coverage.out"
-    - name: Download linter results
-      if: ${{ inputs.CHECK_LINTER == 'true' }}
-      uses: actions/download-artifact@v3
-      with:
-        name: "${{ github.sha }}-lint-results.out"
-    - name: SonarQube Scan
-      uses: sonarsource/sonarqube-scan-action@master
+        FLIPPCIRCLECIPULLER_REPO_TOKEN: ${{ inputs.FLIPPCIRCLECIPULLER_REPO_TOKEN }}
+    - name: Install mockery
+      run: go install github.com/vektra/mockery/v2
+      shell: bash
+    - name: Generate mocks
+      run: make generate-mocks
+      shell: bash
+    - name: Run custom Go test action
+      uses: wishabi/github-actions/go/test@v0
       env:
-        SONAR_TOKEN: ${{ inputs.SONAR_TOKEN }}
-        SONAR_HOST_URL: ${{ inputs.SONAR_HOST_URL }}
+        DB_HOST: ${{ inputs.DB_HOST }}
+        DB_USER: ${{ inputs.DB_USER }}
+        DB_PASSWORD: ${{ inputs.DB_PASSWORD }}
+        DB_PORT: ${{ inputs.DB_PORT }}
       with:
-        args: >
-          -Dsonar.projectVersion=${{ steps.get-short-sha.outputs.short_sha }}
+        TAGS: ${{ inputs.TEST_TAGS }}
     - name: Notify slack channel on failure
-      if: failure() && inputs.SLACK_CHANNEL_ID != null
-      # if: failure() && github.ref == 'refs/heads/main'
+      if: failure() && inputs.SLACK_CHANNEL_ID != null && github.ref == 'refs/heads/main'
       uses: slackapi/slack-github-action@v1.24.0
       env:
         SLACK_BOT_TOKEN: ${{ inputs.SLACK_BOT_TOKEN }}
@@ -69,13 +88,13 @@ runs:
         channel-id: ${{ inputs.SLACK_CHANNEL_ID }}
         payload: |
           {
-            "text": "SonarQube Scan Failed",
+            "text": "Go Build and Test Failed",
             "blocks": [
               {
                 "type": "header",
                 "text": {
                   "type": "plain_text",
-                  "text": "SonarQube Scan Failed",
+                  "text": "Go Build and Test Failed",
                   "emoji": true
                 }
               },
@@ -90,8 +109,8 @@ runs:
                 },
                 "accessory": {
                   "type": "image",
-                  "image_url": "https://emoji.slack-edge.com/T02AJQYGN/sonar-fail/3d49949af6831e63.png",
-                  "alt_text": "sonar fail icon"
+                  "image_url": "https://emoji.slack-edge.com/T02AJQYGN/fail/d35657341d0b7dc4.png",
+                  "alt_text": "error icon"
                 }
               },
               {
@@ -99,10 +118,24 @@ runs:
               },
               {
                 "type": "section",
-                  "text": {
+                "fields": [
+                  {
                     "type": "mrkdwn",
-                    "text": "*Commit*\n${{ steps.get-short-sha.outputs.short_sha }}"
+                    "text": "*Version/Commit*"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Event*"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "${{ steps.get-short-sha.outputs.short_sha }}"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "${{ github.event_name }}"
                   }
+                ]
               },
               {
                 "type": "context",

--- a/go/build-and-test/action.yml
+++ b/go/build-and-test/action.yml
@@ -58,17 +58,21 @@ runs:
         BUF_BUILD_USER: ${{ inputs.BUF_BUILD_USER }}
         BUF_BUILD_API_TOKEN: ${{ inputs.BUF_BUILD_API_TOKEN }}
     - name: Generate local protos
-      run: make generate-buf
+      run: |
+        buf generate
+        go generate ./...
       shell: bash
     - name: Setup Go dependencies
       uses: wishabi/github-actions/go/deps@v0
       with:
         FLIPPCIRCLECIPULLER_REPO_TOKEN: ${{ inputs.FLIPPCIRCLECIPULLER_REPO_TOKEN }}
     - name: Install mockery
+      if: ${{ hashFiles('.mockery.yml') != '' }}
       run: go install github.com/vektra/mockery/v2
       shell: bash
     - name: Generate mocks
-      run: make generate-mocks
+      if: ${{ hashFiles('.mockery.yml') != '' }}
+      run: mockery
       shell: bash
     - name: Run custom Go test action
       uses: wishabi/github-actions/go/test@v0

--- a/go/build-and-test/action.yml
+++ b/go/build-and-test/action.yml
@@ -58,9 +58,11 @@ runs:
         BUF_BUILD_USER: ${{ inputs.BUF_BUILD_USER }}
         BUF_BUILD_API_TOKEN: ${{ inputs.BUF_BUILD_API_TOKEN }}
     - name: Generate local protos
-      run: |
-        buf generate
-        go generate ./...
+      if: ${{ hashFiles('buf.gen.yml') != '' }}
+      run: buf generate
+      shell: bash
+    - name: Run go generate
+      run: go generate ./...
       shell: bash
     - name: Setup Go dependencies
       uses: wishabi/github-actions/go/deps@v0

--- a/go/configure/action.yml
+++ b/go/configure/action.yml
@@ -1,5 +1,5 @@
-name: 'go-configure'
-description: 'Set up Go environment for CI build. Sets up Buf if the relevant inputs are provided.'
+name: "go-configure"
+description: "Set up Go environment for CI build. Sets up Buf if the relevant inputs are provided."
 
 inputs:
   FLIPPCIRCLECIPULLER_REPO_TOKEN:
@@ -17,7 +17,7 @@ inputs:
     default: 1
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Checkout code
       uses: actions/checkout@v3

--- a/go/lint/action.yml
+++ b/go/lint/action.yml
@@ -1,15 +1,16 @@
-name: "SonarQube Scan"
-description: "Runs various quality and security checks against changes"
+name: "Go Lint"
+description: "Lint Go Repo"
+
 inputs:
-  SONAR_HOST_URL:
-    description: secret value
+  FLIPPCIRCLECIPULLER_REPO_TOKEN:
+    description: Flipp circleci repo token
     required: true
-  SONAR_TOKEN:
-    description: secret value
-    required: true
-  CHECK_LINTER:
-    description: whether to download and analyze linter results
-    default: false
+  BUF_BUILD_USER:
+    description: Buf CI user stored as secret
+    required: false
+  BUF_BUILD_API_TOKEN:
+    description: Buf API token stored as secret
+    required: false
   SLACK_CHANNEL_ID:
     description: The Slack channel ID(s) to send the data to
     required: false
@@ -20,9 +21,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: Set branch variable
       id: set-branch
       shell: bash
@@ -38,30 +36,27 @@ runs:
       id: get-short-sha
       run: echo "short_sha=`echo ${GITHUB_SHA::7}`" > $GITHUB_OUTPUT
       shell: bash
-    - name: Downloading test report
-      uses: actions/download-artifact@v3
+    - name: Configure Go environment
+      uses: wishabi/github-actions/go/configure@v0
       with:
-        name: "${{ github.sha }}-test-report.out"
-    - name: Downloading coverage report
-      uses: actions/download-artifact@v3
+        FLIPPCIRCLECIPULLER_REPO_TOKEN: ${{ inputs.FLIPPCIRCLECIPULLER_REPO_TOKEN }}
+        BUF_BUILD_USER: ${{ inputs.BUF_BUILD_USER }}
+        BUF_BUILD_API_TOKEN: ${{ inputs.BUF_BUILD_API_TOKEN }}
+        FETCH_DEPTH: 0
+    - name: Generate local protos
+      run: make generate-buf
+      shell: bash
+    - name: Setup Go dependencies
+      uses: wishabi/github-actions/go/deps@v0
       with:
-        name: "${{ github.sha }}-coverage.out"
-    - name: Download linter results
-      if: ${{ inputs.CHECK_LINTER == 'true' }}
-      uses: actions/download-artifact@v3
+        FLIPPCIRCLECIPULLER_REPO_TOKEN: ${{ inputs.FLIPPCIRCLECIPULLER_REPO_TOKEN }}
+    - name: Run Go linter
+      uses: golangci/golangci-lint-action@v3
       with:
-        name: "${{ github.sha }}-lint-results.out"
-    - name: SonarQube Scan
-      uses: sonarsource/sonarqube-scan-action@master
-      env:
-        SONAR_TOKEN: ${{ inputs.SONAR_TOKEN }}
-        SONAR_HOST_URL: ${{ inputs.SONAR_HOST_URL }}
-      with:
-        args: >
-          -Dsonar.projectVersion=${{ steps.get-short-sha.outputs.short_sha }}
+        skip-cache: true
+        args: --verbose
     - name: Notify slack channel on failure
-      if: failure() && inputs.SLACK_CHANNEL_ID != null
-      # if: failure() && github.ref == 'refs/heads/main'
+      if: failure() && inputs.SLACK_CHANNEL_ID != null && github.ref == 'refs/heads/main'
       uses: slackapi/slack-github-action@v1.24.0
       env:
         SLACK_BOT_TOKEN: ${{ inputs.SLACK_BOT_TOKEN }}
@@ -69,13 +64,13 @@ runs:
         channel-id: ${{ inputs.SLACK_CHANNEL_ID }}
         payload: |
           {
-            "text": "SonarQube Scan Failed",
+            "text": "Go Lint Failed",
             "blocks": [
               {
                 "type": "header",
                 "text": {
                   "type": "plain_text",
-                  "text": "SonarQube Scan Failed",
+                  "text": "Go Lint Failed",
                   "emoji": true
                 }
               },
@@ -90,8 +85,8 @@ runs:
                 },
                 "accessory": {
                   "type": "image",
-                  "image_url": "https://emoji.slack-edge.com/T02AJQYGN/sonar-fail/3d49949af6831e63.png",
-                  "alt_text": "sonar fail icon"
+                  "image_url": "https://emoji.slack-edge.com/T02AJQYGN/lint/84d851e0ac2b58c1.png",
+                  "alt_text": "lint error icon"
                 }
               },
               {
@@ -99,10 +94,24 @@ runs:
               },
               {
                 "type": "section",
-                  "text": {
+                "fields": [
+                  {
                     "type": "mrkdwn",
-                    "text": "*Commit*\n${{ steps.get-short-sha.outputs.short_sha }}"
+                    "text": "*Version/Commit*"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Event*"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "${{ steps.get-short-sha.outputs.short_sha }}"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "${{ github.event_name }}"
                   }
+                ]
               },
               {
                 "type": "context",

--- a/go/lint/action.yml
+++ b/go/lint/action.yml
@@ -44,7 +44,11 @@ runs:
         BUF_BUILD_API_TOKEN: ${{ inputs.BUF_BUILD_API_TOKEN }}
         FETCH_DEPTH: 0
     - name: Generate local protos
-      run: make generate-buf
+      if: ${{ hashFiles('buf.gen.yml') != '' }}
+      run: buf generate
+      shell: bash
+    - name: Run go generate
+      run: go generate ./...
       shell: bash
     - name: Setup Go dependencies
       uses: wishabi/github-actions/go/deps@v0

--- a/go/smoke-test/action.yml
+++ b/go/smoke-test/action.yml
@@ -1,28 +1,20 @@
-name: "SonarQube Scan"
-description: "Runs various quality and security checks against changes"
+name: "Smoke Test"
+description: "Runs Go smoke tests"
 inputs:
-  SONAR_HOST_URL:
-    description: secret value
-    required: true
-  SONAR_TOKEN:
-    description: secret value
-    required: true
-  CHECK_LINTER:
-    description: whether to download and analyze linter results
-    default: false
   SLACK_CHANNEL_ID:
     description: The Slack channel ID(s) to send the data to
     required: false
   SLACK_BOT_TOKEN:
     description: The Slack bot token to pass the data to
     required: false
+  ENV:
+    description: Environment name used for Slack messages
+    required: false
+    default: "ENV input not provided"
 
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: Set branch variable
       id: set-branch
       shell: bash
@@ -38,30 +30,17 @@ runs:
       id: get-short-sha
       run: echo "short_sha=`echo ${GITHUB_SHA::7}`" > $GITHUB_OUTPUT
       shell: bash
-    - name: Downloading test report
-      uses: actions/download-artifact@v3
-      with:
-        name: "${{ github.sha }}-test-report.out"
-    - name: Downloading coverage report
-      uses: actions/download-artifact@v3
-      with:
-        name: "${{ github.sha }}-coverage.out"
-    - name: Download linter results
-      if: ${{ inputs.CHECK_LINTER == 'true' }}
-      uses: actions/download-artifact@v3
-      with:
-        name: "${{ github.sha }}-lint-results.out"
-    - name: SonarQube Scan
-      uses: sonarsource/sonarqube-scan-action@master
+    - name: Restore cache
+      uses: wishabi/github-actions/cache@v0
+    - name: Run Smoke Tests
       env:
-        SONAR_TOKEN: ${{ inputs.SONAR_TOKEN }}
-        SONAR_HOST_URL: ${{ inputs.SONAR_HOST_URL }}
-      with:
-        args: >
-          -Dsonar.projectVersion=${{ steps.get-short-sha.outputs.short_sha }}
+        API_URL: "https://distribution-api-stg.flippback.com"
+        WRITER_API_URL: "https://distribution-api-writer-stg.flippback.com"
+      run: |
+        go test ./tests/smoke --tags=smoke
+      shell: bash
     - name: Notify slack channel on failure
       if: failure() && inputs.SLACK_CHANNEL_ID != null
-      # if: failure() && github.ref == 'refs/heads/main'
       uses: slackapi/slack-github-action@v1.24.0
       env:
         SLACK_BOT_TOKEN: ${{ inputs.SLACK_BOT_TOKEN }}
@@ -69,13 +48,13 @@ runs:
         channel-id: ${{ inputs.SLACK_CHANNEL_ID }}
         payload: |
           {
-            "text": "SonarQube Scan Failed",
+            "text": "Smoke Test Failed",
             "blocks": [
               {
                 "type": "header",
                 "text": {
                   "type": "plain_text",
-                  "text": "SonarQube Scan Failed",
+                  "text": "Smoke Test Failed",
                   "emoji": true
                 }
               },
@@ -86,12 +65,12 @@ runs:
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": "*Repository*\n<https://github.com/${{ github.repository }}|${{ github.repository }}>\n\n*${{ github.event_name == 'pull_request' && 'Pull Request' || 'Branch' }}*\n${{ github.event_name == 'pull_request' && format('<{0}|{1}>', github.event.pull_request.html_url, github.event.pull_request.title) || format('<https://github.com/{0}/commit/{1}|{2}>', github.repository, github.sha, steps.set-branch.outputs.branch)}}"
+                  "text": "*Repository*\n<https://github.com/${{ github.repository }}|${{ github.repository }}>\n\n*Environment*\n${{ inputs.ENV }}"
                 },
                 "accessory": {
                   "type": "image",
-                  "image_url": "https://emoji.slack-edge.com/T02AJQYGN/sonar-fail/3d49949af6831e63.png",
-                  "alt_text": "sonar fail icon"
+                  "image_url": "https://a.slack-edge.com/production-standard-emoji-assets/14.0/apple-large/1f6ad@2x.png",
+                  "alt_text": "smoke test fail icon"
                 }
               },
               {
@@ -99,10 +78,24 @@ runs:
               },
               {
                 "type": "section",
-                  "text": {
+                "fields": [
+                  {
                     "type": "mrkdwn",
-                    "text": "*Commit*\n${{ steps.get-short-sha.outputs.short_sha }}"
+                    "text": "*Branch*"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Commit*"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "${{ format('<https://github.com/{0}/commit/{1}|{2}>', github.repository, github.sha, steps.set-branch.outputs.branch)}}"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "${{ steps.get-short-sha.outputs.short_sha }}"
                   }
+                ]
               },
               {
                 "type": "context",

--- a/go/smoke-test/action.yml
+++ b/go/smoke-test/action.yml
@@ -33,9 +33,6 @@ runs:
     - name: Restore cache
       uses: wishabi/github-actions/cache@v0
     - name: Run Smoke Tests
-      env:
-        API_URL: "https://distribution-api-stg.flippback.com"
-        WRITER_API_URL: "https://distribution-api-writer-stg.flippback.com"
       run: |
         go test ./tests/smoke --tags=smoke
       shell: bash

--- a/sonarqube-scan/action.yml
+++ b/sonarqube-scan/action.yml
@@ -60,8 +60,7 @@ runs:
         args: >
           -Dsonar.projectVersion=${{ steps.get-short-sha.outputs.short_sha }}
     - name: Notify slack channel on failure
-      if: failure() && inputs.SLACK_CHANNEL_ID != null
-      # if: failure() && github.ref == 'refs/heads/main'
+      if: failure() && inputs.SLACK_CHANNEL_ID != null && github.ref == 'refs/heads/main'
       uses: slackapi/slack-github-action@v1.24.0
       env:
         SLACK_BOT_TOKEN: ${{ inputs.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
# Changes

DRYing up existing common functionality in our Go GitHub actions. The goal is for more maintainability, and reducing the friction involved in making quality of life improvements so people are more likely to jump in and make the small tweaks that help us work more effectively.

## Notes

The Slack aspect got a lot WETter. I went back and forth on this a lot. While there is a lot of repeated elements, the Slack messages themselves were getting really clunky with how flexible/generic the single action tried to be. There are also a bunch of gotchas with which parts of the GHA contexts get passed through nested composite actions.

Slack `attachments` are deprecated, so they have been nuked. The biggest downside is no more nice red/green/yellow side bars.

## How to Test

[This PR](https://github.com/wishabi/distribution-api/pull/199) is pointing to this branch so we can try them out. They've all been manually tested.

## New Slack Messages

<img width="740" alt="image" src="https://github.com/wishabi/github-actions/assets/129801576/d3f19513-a87d-4954-bc1b-589026ebb4c4">
<img width="754" alt="image" src="https://github.com/wishabi/github-actions/assets/129801576/43df339b-c078-4d70-a6fd-f3439a2c64d8">
<img width="726" alt="image" src="https://github.com/wishabi/github-actions/assets/129801576/689c951f-0623-4130-81ac-d24657e2f0a3">
<img width="694" alt="image" src="https://github.com/wishabi/github-actions/assets/129801576/2da4a346-d1b7-4568-9c64-75bc7fa4d089">
<img width="723" alt="image" src="https://github.com/wishabi/github-actions/assets/129801576/031bc1f1-d4e0-4c14-9a76-4146d75ea225">
<img width="652" alt="image" src="https://github.com/wishabi/github-actions/assets/129801576/5f65da2a-f974-4b40-a8ad-bc1f871ee7a6">
