### PR TITLE
fix: Add ability to specify version of golangci-lint

### DIFF
--- a/go/lint/action.yml
+++ b/go/lint/action.yml
@@ -17,6 +17,10 @@ inputs:
   SLACK_BOT_TOKEN:
     description: The Slack bot token to pass the data to
     required: false
+  GOLANG_CI_LINT_VERSION:
+    description: The version of golangci-lint to use
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -52,6 +56,7 @@ runs:
       with:
         skip-cache: true
         args: --verbose
+        version: ${{ inputs.GOLANG_CI_LINT_VERSION }} # Optional - if blank, will use the action's default version resolution
     - name: Notify slack channel on failure
       if: failure() && inputs.SLACK_CHANNEL_ID != null && github.ref == 'refs/heads/main'
       uses: slackapi/slack-github-action@v1.24.0


### PR DESCRIPTION
- curator golangci-lint broke locally, switching it to use docker but this means that golangci-lint has an `// indirect` tag at the end of the version in `go.mod` and we won't specify version there anymore
- the golangci-lint action doesn't expect the indirect at the end of the line and complains about a bad version as well
- This allows pass through of a specific version
- Tested in this run on curator: https://github.com/wishabi/curator/actions/runs/7790307499