### PR TITLE
Added backward compatibility for github workspace

### DIFF
--- a/go/lint/action.yml
+++ b/go/lint/action.yml
@@ -57,7 +57,7 @@ runs:
         FLIPPCIRCLECIPULLER_REPO_TOKEN: ${{ inputs.FLIPPCIRCLECIPULLER_REPO_TOKEN }}
     - name: Setup safe directory
       shell: bash
-      run: git config --global --add safe.directory ${{ inputs.WORKSPACE }}
+      run: git config --global --add safe.directory ${{ inputs.WORKSPACE || github.workspace }}
     - name: Run Go linter
       uses: golangci/golangci-lint-action@v3
       with:


### PR DESCRIPTION
- Workspace input was added in a non-backward compatible way, this fixes it to fall back to the github workspace in case it isn't passed
- https://github.com/wishabi/distribution-api/actions/runs/7994562567/job/21832894477?pr=296#step:3:534