### PR TITLE
Allow passthrough of timeout from build-and-test

### DIFF
--- a/go/build-and-test/action.yml
+++ b/go/build-and-test/action.yml
@@ -32,6 +32,10 @@ inputs:
   TEST_TAGS:
     description: Test tags
     required: false
+  TIMEOUT:
+    description: A timeout value. If tests take longer than this, they will fail. Set to an empty string to disable.
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -70,6 +74,7 @@ runs:
         DB_PORT: ${{ inputs.DB_PORT }}
       with:
         TAGS: ${{ inputs.TEST_TAGS }}
+        TIMEOUT: ${{ inputs.TIMEOUT }}
     - name: Notify slack channel on failure
       if: failure() && inputs.SLACK_CHANNEL_ID != null && github.ref == 'refs/heads/main'
       uses: slackapi/slack-github-action@v1.24.0

--- a/go/build-and-test/action.yml
+++ b/go/build-and-test/action.yml
@@ -33,7 +33,7 @@ inputs:
     description: Test tags
     required: false
   TIMEOUT:
-    description: A timeout value. If tests take longer than this, they will fail. Set to an empty string to disable.
+    description: A timeout value seconds. If tests take longer than this, they will fail. Set to an empty string to disable.
     required: false
     default: ""
 

--- a/go/build-and-test/action.yml
+++ b/go/build-and-test/action.yml
@@ -33,7 +33,7 @@ inputs:
     description: Test tags
     required: false
   TIMEOUT:
-    description: A timeout value seconds. If tests take longer than this, they will fail. Set to an empty string to disable.
+    description: A timeout value in seconds. If tests take longer than this, they will fail. Set to an empty string to disable.
     required: false
     default: ""
 

--- a/go/build-and-test/action.yml
+++ b/go/build-and-test/action.yml
@@ -33,7 +33,7 @@ inputs:
     description: Test tags
     required: false
   TIMEOUT:
-    description: A timeout value in seconds. If tests take longer than this, they will fail. Set to an empty string to disable.
+    description: A timeout value in seconds. If tests take longer than this, they will fail. Not setting this value will fallback to go test's default of 10 minutes.
     required: false
     default: ""
 

--- a/go/test/action.yml
+++ b/go/test/action.yml
@@ -8,7 +8,7 @@ inputs:
   TIMEOUT:
     description: A timeout value. If tests take longer than this, they will fail. Set to an empty string to disable.
     required: false
-    default: "30"
+    default: ""
 
 runs:
   using: 'composite'

--- a/go/test/action.yml
+++ b/go/test/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: Set of tags to run tests with.
     required: false
   TIMEOUT:
-    description: A timeout value. If tests take longer than this, they will fail. Set to an empty string to disable.
+    description: A timeout value in seconds. If tests take longer than this, they will fail. Set to an empty string to disable.
     required: false
     default: ""
 

--- a/go/test/action.yml
+++ b/go/test/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: Set of tags to run tests with.
     required: false
   TIMEOUT:
-    description: A timeout value in seconds. If tests take longer than this, they will fail. Set to an empty string to disable.
+    description: A timeout value in seconds. If tests take longer than this, they will fail. Not setting this value will fallback to go test's default of 10 minutes.
     required: false
     default: ""
 


### PR DESCRIPTION
- The default for test timeout is `10m` with go test - keeping the default, but allowing the passthrough of timeout