### PR TITLE
Fix git permissions for runner v2 instances

### DIFF
--- a/go/configure/action.yml
+++ b/go/configure/action.yml
@@ -26,6 +26,9 @@ runs:
     - name: Setting up private modules access
       shell: bash
       run: git config --global url."https://${{ inputs.FLIPPCIRCLECIPULLER_REPO_TOKEN }}:x-oauth-basic@github.com/wishabi".insteadOf "https://github.com/wishabi"
+    - name: Fixing git permissions
+      shell: bash
+      run: git config --global --add safe.directory '*'
     - name: Grab buf version
       if: ${{ hashFiles('.tool-versions') != '' }}
       run: |


### PR DESCRIPTION
This allows the `git diff` line to work correctly. There was some kind of issue with git permissions:

```
fatal: detected dubious ownership in repository at '/__w/content-api/content-api'
To add an exception for this directory, call:

        git config --global --add safe.directory /__w/content-api/content-api
```