### PR TITLE
Revert "Fix git permissions for runner v2 instances"

### DIFF
--- a/go/configure/action.yml
+++ b/go/configure/action.yml
@@ -26,9 +26,6 @@ runs:
     - name: Setting up private modules access
       shell: bash
       run: git config --global url."https://${{ inputs.FLIPPCIRCLECIPULLER_REPO_TOKEN }}:x-oauth-basic@github.com/wishabi".insteadOf "https://github.com/wishabi"
-    - name: Fixing git permissions
-      shell: bash
-      run: git config --global --add safe.directory '*'
     - name: Grab buf version
       if: ${{ hashFiles('.tool-versions') != '' }}
       run: |


### PR DESCRIPTION
This reverts commit f7a5b10.

Turns out we don't need this - we just have to set `HOME=/root` in any action that uses a container.