### PR TITLE
[PD-976] Fixing ruby deps action

### DIFF
--- a/.github/workflows/main-version-update.yml
+++ b/.github/workflows/main-version-update.yml
@@ -12,6 +12,7 @@ on:
         description: The major version to update
         options:
           - v0
+          - v1
 
 jobs:
   tag:

--- a/ruby/deps/action.yml
+++ b/ruby/deps/action.yml
@@ -17,7 +17,7 @@ runs:
         key: rails-${{ hashFiles('Gemfile.lock') }}
         restore-keys: rails-${{ hashFiles('Gemfile.lock') }}
     - name: Set bundle permissions
-      if: steps.bundle-cache.outputs.cache-hit != 'true' && inputs.USE_CIRCLECI_USER
+      if: steps.bundle-cache.outputs.cache-hit != 'true' || inputs.USE_CIRCLECI_USER
       shell: bash
       run: |
         sudo chown -R circleci:circleci /home/circleci/.bundle

--- a/ruby/deps/action.yml
+++ b/ruby/deps/action.yml
@@ -15,7 +15,7 @@ runs:
       if: steps.bundle-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        sudo chown root:root -R /home/root/.bundle
+        sudo chown root:root -R /root/.bundle
         bundle install
       env: 
         BUNDLE_JOBS: 4

--- a/ruby/deps/action.yml
+++ b/ruby/deps/action.yml
@@ -15,7 +15,7 @@ runs:
       if: steps.bundle-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        sudo chown circleci:circleci -R /home/circleci/.bundle
+        sudo chown root:root -R /home/root/.bundle
         bundle install
       env: 
         BUNDLE_JOBS: 4

--- a/ruby/deps/action.yml
+++ b/ruby/deps/action.yml
@@ -15,7 +15,6 @@ runs:
       if: steps.bundle-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        sudo chown root:root -R /root/.bundle
         bundle install
       env: 
         BUNDLE_JOBS: 4

--- a/ruby/deps/action.yml
+++ b/ruby/deps/action.yml
@@ -1,10 +1,5 @@
 name: 'Ruby bundle install and caching'
 description: 'custom GitHub action that runs to setup ruby bundle install and caching'
-inputs:
-  USE_CIRCLECI_USER:
-      description: Flag that controls whether we're assuming `circleci` user
-      required: false
-      default: true
 
 runs:
   using: "composite"
@@ -16,11 +11,6 @@ runs:
         path: vendor/bundle
         key: rails-${{ hashFiles('Gemfile.lock') }}
         restore-keys: rails-${{ hashFiles('Gemfile.lock') }}
-    - name: Set bundle permissions
-      if: steps.bundle-cache.outputs.cache-hit != 'true' && inputs.USE_CIRCLECI_USER
-      shell: bash
-      run: |
-        sudo chown -R circleci:circleci /home/circleci/.bundle
     - name: Bundle install
       if: steps.bundle-cache.outputs.cache-hit != 'true'
       shell: bash

--- a/ruby/deps/action.yml
+++ b/ruby/deps/action.yml
@@ -17,7 +17,7 @@ runs:
         key: rails-${{ hashFiles('Gemfile.lock') }}
         restore-keys: rails-${{ hashFiles('Gemfile.lock') }}
     - name: Set bundle permissions
-      if: steps.bundle-cache.outputs.cache-hit != 'true' || inputs.USE_CIRCLECI_USER
+      if: steps.bundle-cache.outputs.cache-hit != 'true' && inputs.USE_CIRCLECI_USER
       shell: bash
       run: |
         sudo chown -R circleci:circleci /home/circleci/.bundle

--- a/ruby/deps/action.yml
+++ b/ruby/deps/action.yml
@@ -1,5 +1,10 @@
 name: 'Ruby bundle install and caching'
 description: 'custom GitHub action that runs to setup ruby bundle install and caching'
+inputs:
+  USE_CIRCLECI_USER:
+      description: Flag that controls whether we're assuming `circleci` user
+      required: false
+      default: true
 
 runs:
   using: "composite"
@@ -11,6 +16,11 @@ runs:
         path: vendor/bundle
         key: rails-${{ hashFiles('Gemfile.lock') }}
         restore-keys: rails-${{ hashFiles('Gemfile.lock') }}
+    - name: Set bundle permissions
+      if: steps.bundle-cache.outputs.cache-hit != 'true' && inputs.USE_CIRCLECI_USER
+      shell: bash
+      run: |
+        sudo chown -R circleci:circleci /home/circleci/.bundle
     - name: Bundle install
       if: steps.bundle-cache.outputs.cache-hit != 'true'
       shell: bash


### PR DESCRIPTION
This action seems to fail on the v2 runners when there is a cache miss, because `circleci` isn't a user.

Example run: https://github.com/wishabi/publication-api/actions/runs/9101577298/job/25019671496

Run with env: HOME: root, it works: https://github.com/wishabi/publication-api/actions/runs/9113841888/job/25056355440