### PR TITLE
fix: fix the fix to ruby deps to make it backward compatible

### DIFF
--- a/.github/workflows/main-version-update.yml
+++ b/.github/workflows/main-version-update.yml
@@ -12,7 +12,6 @@ on:
         description: The major version to update
         options:
           - v0
-          - v1
 
 jobs:
   tag:

--- a/ruby/deps/action.yml
+++ b/ruby/deps/action.yml
@@ -16,6 +16,9 @@ runs:
       shell: bash
       run: |
         bundle install
+        if id "3434" >/dev/null 2>&1; then
+            sudo chown circleci:circleci -R /home/circleci/.bundle
+        fi
       env: 
         BUNDLE_JOBS: 4
         BUNDLE_DEPLOYMENT: true


### PR DESCRIPTION
We jumped the gun on our previous merge. This will prevent breakages to people already consuming the ruby dep github action but are still on runner fleet v1.