### PR TITLE
pass token to deps

### DIFF
--- a/go/build-and-test/action.yml
+++ b/go/build-and-test/action.yml
@@ -63,6 +63,8 @@ runs:
         BUF_BUILD_API_TOKEN: ${{ inputs.BUF_BUILD_API_TOKEN }}
     - name: Setup Go dependencies
       uses: wishabi/github-actions/go/deps@v0
+      env:
+        BUF_TOKEN: ${{ inputs.BUF_BUILD_API_TOKEN }}
       with:
         FLIPPCIRCLECIPULLER_REPO_TOKEN: ${{ inputs.FLIPPCIRCLECIPULLER_REPO_TOKEN }}
     - name: Run custom Go test action


### PR DESCRIPTION
This is needed because `buf-setup` only works for the other `buf` -provided GitHub Actions like `breaking` and `push`. We call `buf generate` from the command line, so we need the token.