### PR TITLE
Allow libraries not to use deployment mode

### DIFF
--- a/ruby/deps/action.yml
+++ b/ruby/deps/action.yml
@@ -1,5 +1,10 @@
 name: 'Ruby bundle install and caching'
 description: 'custom GitHub action that runs to setup ruby bundle install and caching'
+inputs:
+  library:
+      description: Set to true if installing for a library (no Gemfile.lock)
+      required: false
+      default: ''
 
 runs:
   using: "composite"
@@ -19,8 +24,8 @@ runs:
         if id "3434" >/dev/null 2>&1; then
             sudo chown circleci:circleci -R /home/circleci/.bundle
         fi
-      env: 
+      env:
         BUNDLE_JOBS: 4
-        BUNDLE_DEPLOYMENT: true
+        BUNDLE_DEPLOYMENT: ${{ inputs.library == '' }}
     - name: Caching workspace for deploy jobs
       uses: wishabi/github-actions/cache@v0


### PR DESCRIPTION
Deployment mode requires a Gemfile.lock, which libraries are encouraged not to check in (it doesn't really matter for it). Truth is I don't think deployment mode even matters that much for CI, but :shrug: