### PR TITLE
fix: give the option of not cleaning workspace before eks deploy

### DIFF
--- a/deploy/eks/action.yml
+++ b/deploy/eks/action.yml
@@ -29,6 +29,10 @@ inputs:
   ATOMIC:
     description: EKS Atomic Deployment Flag (true or false) - default is true
     required: false
+  CLEAN_WORKSPACE:
+    description: Whether to clean the workspace before deploying (true or false)
+    required: false
+    default: "true"
 
 runs:
   using: "composite"
@@ -56,6 +60,7 @@ runs:
         aws-region: ${{ inputs.AWS_REGION }}
     - uses: actions/checkout@v4
     - name: Cleaning workspace
+      if: ${{ inputs.CLEAN_WORKSPACE == 'true' }}
       shell: bash
       run: shopt -s dotglob && rm -rf "${{ github.workspace }}"/*
     - name: Restoring workspace from cache


### PR DESCRIPTION
- EKS wipes the workspace by default
- Some jobs (like offers-ranker-model-api) don't want the workspace wiped
- Just set the deploy-eks action to `with.CLEAN_WORKSPACE: 'false'` 