### PR TITLE
Fix test step summary with verbose go test output

### DIFF
--- a/go/test/action.yml
+++ b/go/test/action.yml
@@ -30,20 +30,20 @@ runs:
       run: |
         echo "## Go Test Results" >> $GITHUB_STEP_SUMMARY
         if [ -f test-report.out ]; then
-          PASS=$(grep -c '^ok ' test-report.out || true)
-          FAIL=$(grep -c '^FAIL[[:space:]]' test-report.out || true)
-          SKIP=$(grep -c '\[no test files\]' test-report.out || true)
-          echo "| Status | Packages |" >> $GITHUB_STEP_SUMMARY
-          echo "|--------|----------|" >> $GITHUB_STEP_SUMMARY
+          PASS=$(grep -c '^--- PASS:' test-report.out || true)
+          FAIL=$(grep -c '^--- FAIL:' test-report.out || true)
+          SKIP=$(grep -c '^--- SKIP:' test-report.out || true)
+          echo "| Status | Count |" >> $GITHUB_STEP_SUMMARY
+          echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
           echo "| Passed | ${PASS} |" >> $GITHUB_STEP_SUMMARY
           echo "| Failed | ${FAIL} |" >> $GITHUB_STEP_SUMMARY
-          echo "| No Tests | ${SKIP} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Skipped | ${SKIP} |" >> $GITHUB_STEP_SUMMARY
           if [ "$FAIL" -gt 0 ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "<details><summary>Failed Packages</summary>" >> $GITHUB_STEP_SUMMARY
+            echo "<details><summary>Failed Tests</summary>" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
-            grep '^FAIL[[:space:]]' test-report.out >> $GITHUB_STEP_SUMMARY
+            grep '^--- FAIL:' test-report.out >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
             echo "</details>" >> $GITHUB_STEP_SUMMARY
           fi

--- a/go/test/action.yml
+++ b/go/test/action.yml
@@ -30,8 +30,8 @@ runs:
       run: |
         echo "## Go Test Results" >> $GITHUB_STEP_SUMMARY
         if [ -f test-report.out ]; then
-          PASS=$(grep -c '^ok' test-report.out || true)
-          FAIL=$(grep -c '^FAIL' test-report.out || true)
+          PASS=$(grep -c '^ok ' test-report.out || true)
+          FAIL=$(grep -cP '^FAIL\t' test-report.out || true)
           SKIP=$(grep -c '\[no test files\]' test-report.out || true)
           echo "| Status | Packages |" >> $GITHUB_STEP_SUMMARY
           echo "|--------|----------|" >> $GITHUB_STEP_SUMMARY
@@ -43,7 +43,7 @@ runs:
             echo "<details><summary>Failed Packages</summary>" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
-            grep '^FAIL' test-report.out >> $GITHUB_STEP_SUMMARY
+            grep -P '^FAIL\t' test-report.out >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
             echo "</details>" >> $GITHUB_STEP_SUMMARY
           fi

--- a/go/test/action.yml
+++ b/go/test/action.yml
@@ -31,7 +31,7 @@ runs:
         echo "## Go Test Results" >> $GITHUB_STEP_SUMMARY
         if [ -f test-report.out ]; then
           PASS=$(grep -c '^ok ' test-report.out || true)
-          FAIL=$(grep -cP '^FAIL\t' test-report.out || true)
+          FAIL=$(grep -c '^FAIL[[:space:]]' test-report.out || true)
           SKIP=$(grep -c '\[no test files\]' test-report.out || true)
           echo "| Status | Packages |" >> $GITHUB_STEP_SUMMARY
           echo "|--------|----------|" >> $GITHUB_STEP_SUMMARY
@@ -43,7 +43,7 @@ runs:
             echo "<details><summary>Failed Packages</summary>" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
-            grep -P '^FAIL\t' test-report.out >> $GITHUB_STEP_SUMMARY
+            grep '^FAIL[[:space:]]' test-report.out >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
             echo "</details>" >> $GITHUB_STEP_SUMMARY
           fi

--- a/go/test/action.yml
+++ b/go/test/action.yml
@@ -30,20 +30,20 @@ runs:
       run: |
         echo "## Go Test Results" >> $GITHUB_STEP_SUMMARY
         if [ -f test-report.out ]; then
-          PASS=$(grep -c '^--- PASS:' test-report.out || true)
-          FAIL=$(grep -c '^--- FAIL:' test-report.out || true)
-          SKIP=$(grep -c '^--- SKIP:' test-report.out || true)
-          echo "| Status | Count |" >> $GITHUB_STEP_SUMMARY
-          echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
+          PASS=$(grep -c '^ok' test-report.out || true)
+          FAIL=$(grep -c '^FAIL' test-report.out || true)
+          SKIP=$(grep -c '\[no test files\]' test-report.out || true)
+          echo "| Status | Packages |" >> $GITHUB_STEP_SUMMARY
+          echo "|--------|----------|" >> $GITHUB_STEP_SUMMARY
           echo "| Passed | ${PASS} |" >> $GITHUB_STEP_SUMMARY
           echo "| Failed | ${FAIL} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Skipped | ${SKIP} |" >> $GITHUB_STEP_SUMMARY
+          echo "| No Tests | ${SKIP} |" >> $GITHUB_STEP_SUMMARY
           if [ "$FAIL" -gt 0 ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "<details><summary>Failed Tests</summary>" >> $GITHUB_STEP_SUMMARY
+            echo "<details><summary>Failed Packages</summary>" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
-            grep '^--- FAIL:' test-report.out >> $GITHUB_STEP_SUMMARY
+            grep '^FAIL' test-report.out >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
             echo "</details>" >> $GITHUB_STEP_SUMMARY
           fi

--- a/go/test/test.sh
+++ b/go/test/test.sh
@@ -5,7 +5,7 @@ TAGS=${1:-}
 TIMEOUT=${2:-}
 PARALLEL=${3:-}
 
-cmd="go test ./... -coverprofile=coverage.out"
+cmd="go test -v ./... -coverprofile=coverage.out"
 
 # find non-ignored subdirectories
 file_list=()


### PR DESCRIPTION
- Added `-v` flag to `go test` in `test.sh` so CI gets individual test names
- Step summary now correctly counts individual tests via `^--- PASS:`, `^--- FAIL:`, `^--- SKIP:` patterns
- Failed tests are listed by name in a collapsible details section
- Previous summary was broken: grepped for verbose patterns but `test.sh` ran without `-v`, so all counts showed 0

Tested on inventory-api: https://github.com/wishabi/inventory-api/actions/runs/23457990255