### PR TITLE
deploy/eks: add MULTI_ARCH_BUILD opt-in (QEMU + Buildx)

### DIFF
--- a/deploy/eks/action.yml
+++ b/deploy/eks/action.yml
@@ -36,6 +36,10 @@ inputs:
     description: Whether to clean the workspace before deploying (true or false)
     required: false
     default: "true"
+  MULTI_ARCH_BUILD:
+    description: Set to "true" if build.sh produces multi-arch (amd64 + arm64) images; sets up QEMU and Buildx before the deploy step.
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -74,6 +78,12 @@ runs:
       run: shopt -s dotglob && rm -rf "$GITHUB_WORKSPACE"/*
     - name: Restoring workspace from cache
       uses: wishabi/github-actions/cache@v0
+    - name: Set up QEMU
+      if: ${{ inputs.MULTI_ARCH_BUILD == 'true' }}
+      uses: docker/setup-qemu-action@v4
+    - name: Set up Docker Buildx
+      if: ${{ inputs.MULTI_ARCH_BUILD == 'true' }}
+      uses: docker/setup-buildx-action@v4
     - name: Deploying to EKS via Helm release
       shell: bash
       env:

--- a/deploy/eks/action.yml
+++ b/deploy/eks/action.yml
@@ -37,7 +37,11 @@ inputs:
     required: false
     default: "true"
   MULTI_ARCH_BUILD:
-    description: Set to "true" if build.sh produces multi-arch (amd64 + arm64) images; sets up QEMU and Buildx before the deploy step.
+    description: |
+      Multi-architecture build opt-in for build.sh. When set, the action installs QEMU + Buildx and exports DOCKER_PLATFORMS to the environment so `platform_deploy` (from `platform-infrastructure`) takes the `docker buildx build --push` path. Accepts:
+        - "false" or empty (default): single-arch, no buildx setup
+        - "true": shorthand for "linux/amd64,linux/arm64"
+        - any comma-separated platform list (e.g. "linux/arm64"): used verbatim
     required: false
     default: "false"
 
@@ -78,11 +82,33 @@ runs:
       run: shopt -s dotglob && rm -rf "$GITHUB_WORKSPACE"/*
     - name: Restoring workspace from cache
       uses: wishabi/github-actions/cache@v0
+    - name: Resolve multi-arch platforms
+      id: multi-arch
+      shell: bash
+      env:
+        MULTI_ARCH_INPUT: ${{ inputs.MULTI_ARCH_BUILD }}
+      run: |
+        case "$MULTI_ARCH_INPUT" in
+          ""|"false")
+            platforms=""
+            ;;
+          "true")
+            platforms="linux/amd64,linux/arm64"
+            ;;
+          *)
+            platforms="$MULTI_ARCH_INPUT"
+            ;;
+        esac
+        echo "platforms=$platforms" >> "$GITHUB_OUTPUT"
+        if [ -n "$platforms" ]; then
+          echo "DOCKER_PLATFORMS=$platforms" >> "$GITHUB_ENV"
+          echo "Multi-arch build enabled for platforms: $platforms"
+        fi
     - name: Set up QEMU
-      if: ${{ inputs.MULTI_ARCH_BUILD == 'true' }}
+      if: ${{ steps.multi-arch.outputs.platforms != '' }}
       uses: docker/setup-qemu-action@v4
     - name: Set up Docker Buildx
-      if: ${{ inputs.MULTI_ARCH_BUILD == 'true' }}
+      if: ${{ steps.multi-arch.outputs.platforms != '' }}
       uses: docker/setup-buildx-action@v4
     - name: Deploying to EKS via Helm release
       shell: bash


### PR DESCRIPTION
## Summary
- Adds new optional input `MULTI_ARCH_BUILD` (default `"false"`) to `deploy/eks`
- When `"true"`, runs `docker/setup-qemu-action@v4` and `docker/setup-buildx-action@v4` immediately before the `build.sh` deploy step, so `build.sh`'s `docker buildx build --platform linux/amd64,linux/arm64` works
- Default `"false"` means existing single-arch consumers see no behaviour change

## Motivation
Repos like `ci-build-images` and `base-images` cross-build their docker images for amd64 and arm64. Today their workflows would have to add the QEMU + Buildx setup steps themselves; this folds the pattern into the shared action.

## Usage
```yaml
- uses: wishabi/github-actions/deploy/eks@v0
  with:
    ENV: production
    AWS_ROLE_ARN: arn:aws:iam::...:role/...
    AWS_REGION: us-east-1
    MULTI_ARCH_BUILD: "true"
```

## Test plan
- [ ] Confirm a multi-arch consumer (e.g. `ci-build-images`) deploys cleanly against this branch with `MULTI_ARCH_BUILD: "true"`
- [ ] Confirm an existing single-arch consumer still works untouched (default `"false"` skips the QEMU/Buildx steps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)