### PR TITLE
deploy/eks: skip workspace wipe + restore when no cache exists

### DIFF
--- a/deploy/eks/action.yml
+++ b/deploy/eks/action.yml
@@ -76,11 +76,31 @@ runs:
         aws-secret-access-key: ${{ inputs.AWS_SECRET_ACCESS_KEY }}
         aws-region: ${{ inputs.AWS_REGION }}
     - uses: actions/checkout@v6
+    # Probe for a workspace cache from an earlier job in this workflow run.
+    # The original design assumes a prior "build" job populated the cache,
+    # so the deploy job can wipe the fresh checkout and restore the pre-built
+    # workspace. For single-job workflows there is no such prior cache, and
+    # wiping the workspace would leave `./deploy/build.sh` missing. Probing
+    # via lookup-only lets us skip both the wipe and the restore on a cache
+    # miss, preserving the checkout-populated workspace.
+    # NOTE: path/key must mirror wishabi/github-actions/cache defaults.
+    - name: Probe workspace cache
+      id: cache-probe
+      uses: actions/cache/restore@v5
+      with:
+        path: ./*
+        key: workspace-cache-${{ github.run_id }}
+        lookup-only: true
     - name: Cleaning workspace
-      if: ${{ inputs.CLEAN_WORKSPACE == 'true' }}
+      if: ${{ inputs.CLEAN_WORKSPACE == 'true' && steps.cache-probe.outputs.cache-hit == 'true' }}
       shell: bash
       run: shopt -s dotglob && rm -rf "$GITHUB_WORKSPACE"/*
+    - name: Workspace cache miss — keeping fresh checkout
+      if: ${{ inputs.CLEAN_WORKSPACE == 'true' && steps.cache-probe.outputs.cache-hit != 'true' }}
+      shell: bash
+      run: echo "::notice::No workspace cache found for key 'workspace-cache-${{ github.run_id }}'. Skipping workspace clean and restore; using the freshly checked-out source instead. (This is expected for single-job deploy workflows; multi-job workflows where an earlier job runs wishabi/github-actions/cache@v0 to save the workspace will still hit the clean + restore path.)"
     - name: Restoring workspace from cache
+      if: ${{ steps.cache-probe.outputs.cache-hit == 'true' }}
       uses: wishabi/github-actions/cache@v0
     - name: Resolve multi-arch platforms
       id: multi-arch


### PR DESCRIPTION
## Problem
The `deploy/eks` action's workspace handling assumes a multi-job workflow where an earlier job populated the workspace cache:

1. `actions/checkout@v6` → fresh source in workspace
2. `Cleaning workspace` → `rm -rf "$GITHUB_WORKSPACE"/*` (wipes everything checkout just put there)
3. `Restoring workspace from cache` → expects a hit on `workspace-cache-${{ github.run_id }}` from a sibling job's save

For **single-job workflows** (just one deploy job, no earlier build job that saved the cache), the cache restore is a miss → the workspace stays empty after the wipe → the deploy step fails with:

```
chmod: cannot access './deploy/build.sh': No such file or directory
```

This was hitting `deal-manager-api` in production. The per-consumer workaround is `CLEAN_WORKSPACE: "false"`, but every new single-job-deploy consumer trips over this until they discover the flag.

## Fix
Probe for the cache via `actions/cache/restore@v5` with `lookup-only: true` before deciding to wipe. The probe is a fast metadata-only check (no download).

- **Cache hit** (multi-job consumer's flow): clean + restore run as before. No behaviour change.
- **Cache miss** (single-job consumer's flow): both clean and restore are skipped; a `::notice::` is emitted; the checkout-populated workspace is left intact for `build.sh`.

## Why this is the right shape
- Preserves the original semantics for the multi-job pipeline pattern this action was designed around.
- Removes a sharp edge for single-job consumers — they no longer need to know about `CLEAN_WORKSPACE: "false"`.
- No new inputs; behaviour is automatic based on whether a cache exists.
- The notice in the log explains what happened, so future debugging is straightforward.

## Test plan
- [ ] Smoke-test on a single-job consumer (e.g., `infra-tpsr-registry` or `deal-manager-api`) by pinning to this branch — verify the deploy succeeds with no `CLEAN_WORKSPACE: "false"` override, and the notice appears in the log.
- [ ] Smoke-test on an existing multi-job consumer with an earlier cache-saving job — verify the clean + restore steps still run as before.

## Related
- Diagnosis came out of the deal-manager-api deploy failure during the ARM64 enablement smoke tests. Tracked on the [Confluence project page](https://flippit.atlassian.net/wiki/spaces/EF1/pages/13531775076/Enable+ARM64+and+Graviton+Instances+on+EKS).
- Independent of the ARM64 work — this is a pre-existing quirk that's been latent until single-job deploy workflows started adopting the action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)